### PR TITLE
CMake LINK_FLAGS should be space-delimited

### DIFF
--- a/FindNodeJS.cmake
+++ b/FindNodeJS.cmake
@@ -450,7 +450,9 @@ function(add_nodejs_module NAME)
     if(NOT LINK_FLAGS)
         set(LINK_FLAGS "")
     endif()
-    set(LINK_FLAGS "${LINK_FLAGS} ${NodeJS_LINK_FLAGS}")
+    foreach(NodeJS_LINK_FLAG ${NodeJS_LINK_FLAGS})
+        set(LINK_FLAGS "${LINK_FLAGS} ${NodeJS_LINK_FLAG}")
+    endforeach()
     set_target_properties(${NAME} PROPERTIES
         PREFIX ""
         SUFFIX ".node"


### PR DESCRIPTION
Fixes an issue where, on Windows, we're getting a single link flag:
/IGNORE:4199"%3B"/DELAYLOAD:electron.exe"%3B"/DELAYLOAD...

Could work around it in our CMakeLists by getting the link_flags from the
target, looping through them and writing them back to the target's link flags
with spaces, but I'd rather fix it at the source.

It looks like this may have been broken for a while but only shows up on
Windows because Windows is the only platform that ends up with multiple
values in NodeJS_LINK_FLAGS
