### PR TITLE
Guard against download failure

### DIFF
--- a/util/NodeJSUtil.cmake
+++ b/util/NodeJSUtil.cmake
@@ -42,11 +42,19 @@ function(nodejs_download URL FILE)
 
     # Download the file
     message(STATUS "Downloading: ${URL}")
-    file(DOWNLOAD 
+    file(DOWNLOAD
         ${URL}
-        ${FILE}
+        ${FILE}.tmp
         SHOW_PROGRESS
+        STATUS RESULT
     )
+    list(GET RESULT 0 STATUS)
+    if(STATUS)
+        list(GET result 1 MESSAGE)
+        message(FATAL_ERROR "Unable to download ${URL}: ${MESSAGE}")
+    else()
+        file(RENAME ${FILE}.tmp ${FILE})
+    endif()
 
     # Make sure the file has contents
     nodejs_check_file(${FILE} "Unable to download ${URL}")


### PR DESCRIPTION
Sometimes, the download fails, and on repeated invocations, I'm getting this:

```
-- Validating: /home/mapbox/build/linux-build/node-v4.4.5/headers.tar.gz
CMake Error at node_modules/node-cmake/util/NodeJSUtil.cmake:57 (file):
  file does not recognize sub-command OFF
Call Stack (most recent call first):
  node_modules/node-cmake/FindNodeJS.cmake:309 (nodejs_download)
  cmake/node.cmake:9 (find_package)
  CMakeLists.txt:72 (include)


-- Checksum: SHA256
-- Download: 
CMake Error at node_modules/node-cmake/util/NodeJSUtil.cmake:62 (message):
  Validation failure:
  /home/mapbox/build/linux-build/node-v4.4.5/headers.tar.gz
Call Stack (most recent call first):
  node_modules/node-cmake/FindNodeJS.cmake:309 (nodejs_download)
  cmake/node.cmake:9 (find_package)
  CMakeLists.txt:72 (include)


-- Configuring incomplete, errors occurred!
```

The reason for this is that `${CMAKE_BINARY_DIR}/node-v4.4.5/CHECKSUM` is empty. I found that instead of downloading to the intended path, downloading to a temporary file, then renaming guards against these types of errors.
