### PR TITLE
Use set_target_properties instead of target_link_libraries to add LINK_FLAGS

### DIFF
--- a/NodeJS.cmake
+++ b/NodeJS.cmake
@@ -580,7 +580,7 @@ function(add_nodejs_module NAME)
     target_include_directories(${NAME} PUBLIC ${NODEJS_INCLUDE_DIRS})
 
     # Add link flags to the module
-    target_link_libraries(${NAME} ${NODEJS_LINK_FLAGS} ${NODEJS_LIBRARIES})
+    target_link_libraries(${NAME} ${NODEJS_LIBRARIES})
 
     # Set required properties for the module to build properly
     # Correct naming, symbol visiblity and C++ standard
@@ -594,6 +594,7 @@ function(add_nodejs_module NAME)
         POSITION_INDEPENDENT_CODE TRUE
         CMAKE_CXX_STANDARD_REQUIRED TRUE
         CXX_STANDARD 11
+        LINK_FLAGS "${NODEJS_LINK_FLAGS}"
     )
 
     # Make sure we're buiilding in a build specific output directory


### PR DESCRIPTION
Since 2.0, node-cmake passes the LINK_FLAGS via `target_link_libraries`, but it should continue to use `set_target_properties` as per the [CMake document](https://cmake.org/cmake/help/v3.7/command/target_link_libraries.html?highlight=target_link_libraries#id2):

> Link flags specified here are inserted into the link command in the same place as the link libraries. This might not be correct, depending on the linker. Use the `LINK_FLAGS` target property to add link flags explicitly. The flags will then be placed at the toolchain-defined flag position in the link command.

Fixes for https://github.com/cjntaylor/node-cmake/issues/17 for non-Windows builds.

