### PR TITLE
Prefers node over system-wide nodejs binary

### DIFF
--- a/NodeJS.cmake
+++ b/NodeJS.cmake
@@ -208,7 +208,7 @@ function(nodejs_init)
         endif()
         # Fall back to the "latest" version if node isn't installed
         set(VERSION ${NODEJS_VERSION_FALLBACK})
-        find_program(NODEJS_BINARY NAMES nodejs node)
+        find_program(NODEJS_BINARY NAMES node nodejs)
         if(NODEJS_BINARY)
             execute_process(
                 COMMAND ${NODEJS_BINARY} --version


### PR DESCRIPTION
Users on Debian and Ubuntu might have a `nodejs` binary installed via the `nodejs` package in `apt`.
If they're using e.g. `nvm` to install a local `node` we should always try the `node` binary first.

The Ubuntu `nodejs` package installs a `nodejs` binary system-wide which we then pick up via `find_program`. Changing the order makes sure we do not use the system-wide `nodejs` binary if local `node` binaries are present.

---

Example

```
$ node --version
v4.4.7
$ nodejs --version
v0.10.25
```

Without this patch, picks up system-wide `nodejs` binary

```
-- Downloading: https://nodejs.org/download/release/v0.10.25/SHASUMS256.txt
CMake Error at cmake/NodeJS.cmake:289 (message):
  Unable to extract header archive checksum
```

(Not sure why the header checksum then fails here, should probably be investigated separately)

With this patch, picks up local `node` binary
```
-- Downloading: https://nodejs.org/download/release/v4.4.7/node-v4.4.7-headers.tar.gz
```