### PR TITLE
Include node headers as system headers

### DIFF
--- a/NodeJS.cmake
+++ b/NodeJS.cmake
@@ -600,7 +600,7 @@ function(add_nodejs_module NAME)
         PUBLIC ${NODEJS_DEFINITIONS}
     )
     # This properly defines includes for the module
-    target_include_directories(${NAME} PUBLIC ${NODEJS_INCLUDE_DIRS})
+    target_include_directories(${NAME} SYSTEM PUBLIC ${NODEJS_INCLUDE_DIRS})
 
     # Add link flags to the module
     target_link_libraries(${NAME} ${NODEJS_LIBRARIES})


### PR DESCRIPTION
This will avoid problems were GCC/clang might trigger useless warnings induced by including the `v8` header.