### PR TITLE
Added support to read arguments from npm env variables

### DIFF
--- a/lib/ncmake.js
+++ b/lib/ncmake.js
@@ -55,7 +55,8 @@ argparse = argparse
   .alias('help', 'h')
   .alias('output', 'o')
   .alias('generator', 'g')
-  .alias('arch', 'a');
+  .alias('arch', 'a')
+  .alias('dist-url','disturl');
 
 // Use Ninja on platforms where it is installed as a default
 // (since its significantly faster than make)
@@ -83,6 +84,9 @@ argparse = argparse
   .default('generator', generator)
   .default('debug', false)
   .default('arch', process.arch);
+
+// support for inheriting config env variables from npm
+argparse.env('npm_config_');
 
 // Exactly one command must be specified
 argparse = argparse.demandCommand(1, 1);
@@ -167,8 +171,8 @@ var commands = {
 
     if(argv.generator !== 'default') args.push('-G', argv.generator);
     if(argv.target) args.push('-DNODEJS_VERSION=' + argv.target);
-    if(argv.distUrl) args.push('-DNODEJS_URL="' + argv.distUrl + '"');
-    if(argv.name) args.push('-DNODEJS_NAME="' + argv.name + '"');
+    if(argv.distUrl) args.push('-DNODEJS_URL=' + argv.distUrl);
+    if(argv.name) args.push('-DNODEJS_NAME=' + argv.name);
     args.push.apply(args, argv._.slice(1)); // Include any additional arguments passed to ncmake
     args.push('..');
 


### PR DESCRIPTION
This PR adds 

```javascript
argparse.env('npm_config_');
```

to grab the npm config env variables. This feature mimics node-gyp's (implemented around Line 150 in `lib/node-gyp.js`), and has been tested with electron runtime setup:

https://electronjs.org/docs/tutorial/using-native-node-modules

A couple other related changes:

* `dist-url`/`disturl` alias is added
* double quotes around the values of `NODEJS_URL` and `NODEJS_NAME` are removed as the quotation marks remain in the defined strings in CMake.
