### PR TITLE
Removed extra double quotes for NODEJS_URL and NODEJS_NAME

### DIFF
--- a/lib/ncmake.js
+++ b/lib/ncmake.js
@@ -167,8 +167,8 @@ var commands = {
 
     if(argv.generator !== 'default') args.push('-G', argv.generator);
     if(argv.target) args.push('-DNODEJS_VERSION=' + argv.target);
-    if(argv.distUrl) args.push('-DNODEJS_URL="' + argv.distUrl + '"');
-    if(argv.name) args.push('-DNODEJS_NAME="' + argv.name + '"');
+    if(argv.distUrl) args.push('-DNODEJS_URL=' + argv.distUrl);
+    if(argv.name) args.push('-DNODEJS_NAME=' + argv.name);
     args.push.apply(args, argv._.slice(1)); // Include any additional arguments passed to ncmake
     args.push('..');
 


### PR DESCRIPTION
Removed extra double quotes causing an error when defining an URL or Name.

For example, used with electron :

`ncmake --target v1.8.4 --dist-url https://atom.io/download/electron --name iojs rebuild`